### PR TITLE
Use uppercase tagName to determine custom tag

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,6 +1,5 @@
 var Syntax = require('jstransform/node_modules/esprima-fb').Syntax;
 var utils = require('jstransform/src/utils');
-var knownTags = require('./tags');
 
 
 /**
@@ -36,7 +35,8 @@ function visitNode(traverse, object, path, state) {
 
 	utils.catchup(openingEl.range[0], state, trimLeft);
 
-	var knownTag = (~options.tags.indexOf(nameObj.name)
+	var tagName = nameObj.name;
+	var knownTag = (tagName[0] !== tagName[0].toUpperCase())
 	&& nameObj.type === Syntax.XJSIdentifier);
 
 	if (knownTag) {


### PR DESCRIPTION
This is how React's JSX works now, and it'll mean you don't need to list all of the tag names. 

There will be some more to changes to make, but just wanted to gauge your thoughts first.