### PR TITLE
dont pass Component(null) when no children or attributes

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -34,6 +34,7 @@ function visitNode(traverse, object, path, state) {
   var tagName = nameObj.name;
   var isJSXIdentifier = nameObj.type === Syntax.JSXIdentifier;
   var knownTag = tagName[0] !== tagName[0].toUpperCase() && isJSXIdentifier;
+  var secondArg = false;
 
   if (knownTag) {
     if (options.tagMethods) {
@@ -58,24 +59,25 @@ function visitNode(traverse, object, path, state) {
       utils.append('(', state);
     } else {
       // DOM('div', ...)
-      utils.append("', ", state);
+      utils.append("'", state);
+      secondArg = true
     }
   } else if (options.docblockUnknownTags) {
     // DOM(Component, ...)
     if (options.unknownTagsAsString) {
-      utils.append("', ", state);
-    } else {
-      utils.append(', ', state);
+      utils.append("'", state);
     }
+    secondArg = true
   } else {
     // Component(...)
     utils.append('(', state);
   }
 
   if (attributes.length) {
+    if (secondArg) {
+      utils.append(', ', state);
+    }
     utils.append('{', state);
-  } else {
-    utils.append('null', state);
   }
 
   attributes.forEach(function(attr, index) {
@@ -126,6 +128,12 @@ function visitNode(traverse, object, path, state) {
   });
 
   if (children.length) {
+    if (!attributes.length) {
+      if (secondArg) {
+        utils.append(', ', state);
+      }
+      utils.append('null', state);
+    }
     var lastRenderableIndex;
 
     children.forEach(function(child, index) {

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -5,7 +5,9 @@ module.exports = function () {
   var profile = Component(null, [x = 2])
   var h1 = DOM('h1', {class: "header"}, ["Hello ", firstName + " " + lastName]);
 
-  if (x < 2) {
+  if (x < 1) {
+    return DOM('div')
+  } else if (x < 2) {
     return DOM('h1', null, ["One is less than two"]);
   } else {
     return DOM('div', {class: "title"}, [DOM('h1', null, ["elements can be nested"])]);

--- a/test/fixture.jsx
+++ b/test/fixture.jsx
@@ -5,7 +5,9 @@ module.exports = function () {
   var profile = <Component>{x = 2}</Component>
   var h1 = <h1 class="header">Hello {firstName + " " + lastName}</h1>;
 
-  if (x < 2) {
+  if (x < 1) {
+    return <div></div>
+  } else if (x < 2) {
     return <h1>One is less than two</h1>;
   } else {
     return <div class="title"><h1>elements can be nested</h1></div>;


### PR DESCRIPTION
Small optimisation that returns `DOM('div')` instead of `DOM('div', null)` for tags without attributes and children.

This is partially helpful a if you are using closure to compiler because then you dont have todo things like this.

```javascript
/** @param {Object} state */
function App(state) {
  return (
    <div>
      {... my app ...}
      <Footer/>
    </div>
  )
}

/** @param {Object=} ignore */
function Footer(ignore) {
  return <div>...</div>
}

```