### PR TITLE
Adds new option passArray to bring inline with react-tools/babel jsx

### DIFF
--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -50,6 +50,9 @@ var trimTrailingSpaces = require('./trimTrailingSpaces');
  * @param {Boolean=} options.unknownTagsAsString Pass unknown tags as string
  * instead of object when `options.docblockUnknownTags` is true.
  * @param {String} options.jsx Constructor name (default: set by docblock).
+ * @param {String} options.passArray if false follows default react-tools/babel jsx behavour
+ * `DOM('h1', null, "hello", firstName + " " + lastName)` instead of
+ * `DOM('h1', null, ["Hello ", firstName + " " + lastName])`.
  * @returns {String}
  */
 function transform(str, options) {
@@ -60,6 +63,11 @@ function transform(str, options) {
   // parses the file as an ES6 module, except disabled implicit strict-mode
   if (typeof options.sourceType === 'undefined') {
     options.sourceType = 'nonStrictModule';
+  }
+
+  // defaults to true to keep existing behaviour (but inconsietent with babel and react-tools)
+  if (typeof options.passArray === 'undefined') {
+    options.passArray = true
   }
 
   var transformed = jstransform([visitNode], str, options).code;

--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -15,6 +15,7 @@ var utils = require('jstransform/src/utils');
 function visitNode(traverse, object, path, state) {
   var options = state.g.opts;
   var ident = (options.jsx || utils.getDocblock(state).jsx);
+  var passArray = options.passArray
   var openingEl = object.openingElement;
   var closingEl = object.closingElement;
   var nameObj = openingEl.name;
@@ -139,7 +140,7 @@ function visitNode(traverse, object, path, state) {
       utils.append(', ', state);
     }
 
-    if (children.length) {
+    if (passArray && children.length) {
       utils.append('[', state);
     }
 
@@ -174,7 +175,7 @@ function visitNode(traverse, object, path, state) {
     utils.move(closingEl.range[1], state);
   }
 
-  if (children.length) {
+  if (passArray && children.length) {
     utils.append(']', state);
   }
 

--- a/test/fixture_arrayArgs.js
+++ b/test/fixture_arrayArgs.js
@@ -1,0 +1,13 @@
+/** @jsx DOM */
+
+module.exports = function () {
+  var x = 1;
+  var profile = Component(null, x = 2)
+  var h1 = DOM('h1', {class: "header"}, "Hello ", firstName + " " + lastName);
+
+  if (x < 2) {
+    return DOM('h1', null, "One is less than two");
+  } else {
+    return DOM('div', {class: "title"}, DOM('h1', null, "elements can be nested"));
+  }
+};

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -98,4 +98,18 @@ describe('jsx.transform()', function() {
       expect(result).to.not.contain("class:");
     });
   });
+
+  describe('options.passArray', function() {
+    it('dont pass array for children', function() {
+      var arrayArgsJS = fs.readFileSync(
+        path.join(__dirname, 'fixture_arrayArgs.js'),
+        'utf8'
+      );
+      var result = jsx.transform(fixtureJSX, {
+        passArray: false
+      });
+      expect(result).to.be.a('string');
+      expect(result).to.equal(arrayArgsJS);
+    })
+  })
 });


### PR DESCRIPTION
Currently any child elements will be returned in an array (which is what virtual-dom currently expects/needs) but react-tools and babel both avoid the unnecessary array creation by passing child elements as arguments 3 onwards.

The following enables you to customise the behaviour with a passArray flag (not sure its the best name?)

Personally I would favour consistently/performance with react/babel over virtual-dom but so as not to break backwards compatibility I defaulted the flag to keep the existing behaviour.