### PR TITLE
Fix browserify function

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [module:jsx-transform.fromString](module:jsx-transform.fromString) for optio
 **Example**  
 ```javascript
 var browserify = require('browserify');
-var jsxify = require('jsx-transform').browserify;
+var jsxify = require('jsx-transform').browserifyTransform;
 
 browserify()
   .transform(jsxify(options))

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ var browserify = require('browserify');
 var jsxify = require('jsx-transform').browserifyTransform;
 
 browserify()
-  .transform(jsxify(options))
+  .transform(jsxify, options)
   .bundle()
 ```
 

--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -103,7 +103,7 @@ function fromFile(path, options) {
  *
  * ```javascript
  * var browserify = require('browserify');
- * var jsxify = require('jsx-transform').browserify;
+ * var jsxify = require('jsx-transform').browserifyTransform;
  *
  * browserify()
  *   .transform(jsxify(options))

--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -95,7 +95,7 @@ function fromFile(path, options) {
 }
 
 /**
- * Return a browserify transform.
+ * Make a browserify transform.
  *
  * See {@link module:jsx-transform.fromString} for options.
  *
@@ -106,22 +106,21 @@ function fromFile(path, options) {
  * var jsxify = require('jsx-transform').browserifyTransform;
  *
  * browserify()
- *   .transform(jsxify(options))
+ *   .transform(jsxify, options)
  *   .bundle()
  * ```
  *
+ * @param {String=} filename
  * @param {Object=} options
  * @returns {Function} browserify transform
  */
-function browserifyTransform(options) {
-  return function (filename) {
-    return through(function (buf, enc, next) {
-      try {
-        this.push(fromString(buf.toString('utf8'), options));
-        next();
-      } catch (err) {
-        next(err);
-      }
-    });
-  }
+function browserifyTransform(filename, options) {
+  return through(function (buf, enc, next) {
+    try {
+      this.push(fromString(buf.toString('utf8'), options));
+      next();
+    } catch (err) {
+      next(err);
+    }
+  });
 }


### PR DESCRIPTION
@alexmingoia `browserifyTransform` doesn't comply `browserify`'s rules https://github.com/substack/node-browserify#btransformtr-opts:
```
In both cases, these options are provided as the second argument to the transform function:
module.exports = function (file, opts) { /* opts.bar === 555 */ }
```
Fixed this and another docs typo. Thanks