### PR TITLE
Possibility of adding an ignore regExp option to jsx?

### DIFF
--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -116,12 +116,18 @@ function fromFile(path, options) {
 function browserifyTransform(options) {
   return function (filename) {
     return through(function (buf, enc, next) {
-      try {
-        this.push(fromString(buf.toString('utf8'), options));
+      if( options && options.ignore && filename.match( options.ignore ) ){
+        this.push(buf.toString('utf8'));
         next();
-      } catch (err) {
-        next(err);
+      }else{
+        try {
+          this.push(fromString(buf.toString('utf8'), options));
+          next();
+        } catch (err) {
+          next(err);
+        }        
       }
+
     });
   }
 }


### PR DESCRIPTION
( This isn't a fully complete PR )

But wanted to ask if it was possible to add something similar to prevent the JSX transform running on certain files?

I have some large json files that are causing compile errors...