### PR TITLE
spreadFn now properly comma-separated

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -75,7 +75,7 @@ function visitNode(traverse, object, path, state) {
   }
 
   if (hasAtLeastOneSpreadAttribute) {
-    utils.append(spreadFn + '({', state);
+    utils.append(', ' + spreadFn + '({', state);
   } else if (attributes.length) {
     if (secondArg) {
       utils.append(', ', state);


### PR DESCRIPTION
Using spread attributes would previously output:
`factory('element-name'Object.assign({},propsObj), factory('child-element-name');`
Now it will output:
`factory('element-name', Object.assign({},propsObj), factory('child-element-name');`