### PR TITLE
fromFile correctly calls jstransform and passes default options

### DIFF
--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -51,6 +51,25 @@ module.exports = {
  * @returns {String}
  */
 function fromString(str, options) {
+  options = processOptions(options);
+
+  var transformed = jstransform([visitNode], str, options).code;
+
+  return trimTrailingSpaces(transformed);
+}
+
+/**
+ * @param {String} path
+ * @param {Object=} options
+ * @returns {String}
+ */
+function fromFile(path, options) {
+  options = processOptions(options);
+  var transformed = jstransform([visitNode], fs.readFileSync(path, 'utf8'), options).code;
+  return trimTrailingSpaces(transformed);
+}
+
+function processOptions(options){
   if (typeof options !== 'object') {
     options = {};
   }
@@ -66,7 +85,7 @@ function fromString(str, options) {
 
   // defaults to true to keep existing behaviour (but inconsietent with babel and react-tools)
   if (typeof options.arrayChildren === 'undefined') {
-    options.arrayChildren = true
+    options.arrayChildren = true;
   }
 
   if (typeof options.spreadFn !== 'string') {
@@ -77,20 +96,7 @@ function fromString(str, options) {
     options.unknownTagPattern = '{tag}';
   }
 
-  var transformed = jstransform([visitNode], str, options).code;
-
-  return trimTrailingSpaces(transformed);
-}
-
-/**
- * @param {String} path
- * @param {Object=} options
- * @returns {String}
- */
-function fromFile(path, options) {
-  var transformed = transform(fs.readFileSync(path, 'utf8'), options);
-
-  return trimTrailingSpaces(transformed);
+  return options;
 }
 
 /**


### PR DESCRIPTION
Also refactored default option code into a `processOptions` function that both fromString and fromFile can use