### PR TITLE
Another comma separation fix for spreadFn

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -78,7 +78,7 @@ function visitNode(traverse, object, path, state) {
     if (options.passUnknownTagsToFactory) {
       utils.append(', ' + spreadFn + '({', state);
     } else {
-      utils.append(spreadFn + '({', state);
+      utils.append(', ' + spreadFn + '({', state);
     }
   } else if (attributes.length) {
     if (secondArg) {


### PR DESCRIPTION
Previous merge of my patch only worked if options.passUnknownTagsToFactory returned true.