### PR TITLE
Add browserify.js file to support usage as a browserify CLI transform

### DIFF
--- a/browserify.js
+++ b/browserify.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/jsx.js').browserifyTransform;


### PR DESCRIPTION
* Now also works as a [package.json configured transform](https://github.com/substack/node-browserify#browserifytransform) 

I would like to use your tool, but I quickly noticed that I wasn't able to, since it only exports the browserify functionality when required from another module.  Some people find it better to configure browserify transforms in package.json where you have to define the module name and a configuration object for it.
Also a lot of people just use the browserify CLI without any build tool.

Now it's possible to list this module as a browserify transform in package.json like this

```
  "browserify": {
    "transform": [
      ["jsx-transform/browserify", {"factory": "h"}]
    ]
  }
```
