### PR TITLE
make jsx-transform work under npm 3.x

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,4 +1,4 @@
-var Syntax = require('jstransform/node_modules/esprima-fb').Syntax;
+var Syntax = require('esprima-fb').Syntax;
 var utils = require('jstransform/src/utils');
 
 module.exports = visitNode;


### PR DESCRIPTION
require 'esprima-fb' directly rather than relying on it explicitly being in the node_modules directory as this does not work in npm 3.x