### PR TITLE
Fixes nested node_modules require. Fixes non-SPDX license ID

### DIFF
--- a/lib/visitor.js
+++ b/lib/visitor.js
@@ -1,4 +1,4 @@
-var Syntax = require('jstransform/node_modules/esprima-fb').Syntax;
+var Syntax = require('esprima-fb').Syntax;
 var utils = require('jstransform/src/utils');
 
 module.exports = visitNode;

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "hyperscript"
   ],
   "author": "Alex Mingoia <talk@alexmingoia.com>",
-  "license": "BSD",
+  "license": "0BSD",
   "bugs": {
     "url": "https://github.com/alexmingoia/jsx-transform/issues"
   },
   "homepage": "https://github.com/alexmingoia/jsx-transform",
   "dependencies": {
+    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "jstransform": "^11.0.0",
     "through2": "^0.6.5"
   },


### PR DESCRIPTION
Due to the way npm handles the node_modules hierarchy, we cannot guarantee that esprima-fb will be in the jstransform/node_modules folder. Explicitly declare this dependency. Npm will manage any package redundancy for you.

Also npm was throwing a warning due to the license being non-SPDX.