### PR TITLE
Delay file transformation until we have received all chunks

### DIFF
--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -164,13 +164,21 @@ browserifyTransform.configure = function (options) {
   }
 
   return function (filename) {
-    return through(function (buf, enc, next) {
+    if (!~options.extensions.indexOf(getExtension(filename))) {
+      // We don't need to apply any transforms, just provide a simple pass-through stream
+      return through();
+    }
+
+    var data = "";
+
+    return through(function (chunk, enc, next) {
+      // This function receives chunks of data and we don't want to perform any transforms on an incomplete file.
+      // We buffer the data until the flush function is called. We can then safely perform the transforms on the full file.
+      data += chunk.toString('utf8');
+      next();
+    }, function (next) {
       try {
-        if (~options.extensions.indexOf(getExtension(filename))) {
-          this.push(fromString(buf.toString('utf8'), options));
-        } else {
-          this.push(buf.toString());
-        }
+        this.push(fromString(data, options));
         next();
       } catch (err) {
         next(err);


### PR DESCRIPTION
The transformFunction receives chunks of the file. Attempting to perform any transforms on this chunk will cause errors when the chunk isn't the full file.

This issue was briefly discussed in an [issue on module-deps](https://github.com/browserify/module-deps/issues/162).